### PR TITLE
 Updated the projectType enum value in frontend. Added timeout handling and logging to the log streaming functionality in backend

### DIFF
--- a/client/src/components/pages/createdeployment-form.tsx
+++ b/client/src/components/pages/createdeployment-form.tsx
@@ -23,7 +23,7 @@ import { Plus, Minus } from 'lucide-react';
 
 const deploymentFormSchema = z.object({
   jobName: z.string().min(1, 'Job name is required'),
-  projectType: z.enum(['.NET Core', 'Node.js']),
+  projectType: z.enum(['DotNetCore', 'NodeJs']),
   imageName: z.string().min(1, 'Image name is required'),
   envVars: z
     .array(
@@ -52,7 +52,7 @@ const DeploymentForm: React.FC<DeploymentFormProps> = ({
     resolver: zodResolver(deploymentFormSchema),
     defaultValues: {
       jobName: '',
-      projectType: '.NET Core',
+      projectType: 'DotNetCore',
       imageName: '',
       envVars: [{ key: '', value: '' }],
     },
@@ -92,8 +92,8 @@ const DeploymentForm: React.FC<DeploymentFormProps> = ({
                   </SelectTrigger>
                 </FormControl>
                 <SelectContent>
-                  <SelectItem value='.NET Core'>.NET Core</SelectItem>
-                  <SelectItem value='Node.js'>Node.js</SelectItem>
+                  <SelectItem value='DotNetCore'>.NET Core</SelectItem>
+                  <SelectItem value='NodeJs'>Node.js</SelectItem>
                 </SelectContent>
               </Select>
               <FormMessage>{errors?.projectType}</FormMessage>

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -48,7 +48,7 @@ export interface Build {
 export interface CreateJobInput {
   jobName: string;
   imageName: string;
-  projectType: '.NET Core' | 'Node.js';
+  projectType: 'DotNetCore' | 'NodeJs';
   envVars: Record<string, string>;
 }
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -16,6 +16,7 @@
         "dayjs": "^1.11.13",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
+        "express-rate-limit": "^7.4.0",
         "helmet": "^7.1.0",
         "jenkins": "^1.1.0",
         "jsonwebtoken": "^9.0.2",
@@ -2006,6 +2007,21 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.4.0.tgz",
+      "integrity": "sha512-v1204w3cXu5gCDmAvgvzI6qjzZzoMWKnyVDk3ACgfswTQLYiGen+r8w0VnXnGMmzEN/g8fwIQ4JrFFd4ZP6ssg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": "4 || 5 || ^5.0.0-beta.1"
       }
     },
     "node_modules/fast-copy": {

--- a/server/package.json
+++ b/server/package.json
@@ -21,6 +21,7 @@
     "dayjs": "^1.11.13",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
+    "express-rate-limit": "^7.4.0",
     "helmet": "^7.1.0",
     "jenkins": "^1.1.0",
     "jsonwebtoken": "^9.0.2",

--- a/server/src/helpers/pipeline.ts
+++ b/server/src/helpers/pipeline.ts
@@ -142,8 +142,16 @@ EOF
               kubectl --token $api_token --server http://127.0.0.1:44291 --insecure-skip-tls-verify=true apply -f service.yaml
               kubectl --token $api_token --server http://127.0.0.1:44291 --insecure-skip-tls-verify=true wait --for=condition=ready pod -l app=${sanitizedProjectType}-app --timeout=120s -n ${namespace}
               echo 'Deployment completed successfully'
+
+              # Construct the localhost URL
+              APP_URL="http://localhost:7080"
+              echo "Application URL: $APP_URL"
+              
+              # Save the URL to a temporary file
+              echo "$APP_URL" > /tmp/${namespace}_url.txt
+
               kubectl --token $api_token --server http://127.0.0.1:44291 --insecure-skip-tls-verify=true port-forward service/${sanitizedProjectType}-service 7080:8080 -n ${namespace}
-            '''
+              '''
           } catch (Exception e) {
             echo 'Deployment failed: ' + e.message
             sh '''

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -2,6 +2,7 @@ import express, { type Application } from "express";
 import config from "config";
 import cors from "cors";
 import helmet from "helmet";
+import rateLimit from "express-rate-limit";
 import { log } from "./utils/logger";
 import { routes } from "./routes/routes";
 import { notFoundMiddleware } from "./middlewares/notFoundMiddleware";
@@ -13,6 +14,15 @@ const app: Application = express();
 app.use(helmet());
 app.use(cors());
 app.use(express.json());
+
+// Rate limiting middleware
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+  message: "Too many requests from this IP, please try again later"
+});
+
+app.use(limiter);
 
 const PORT = config.get<number>("port");
 

--- a/server/src/routes/routes.ts
+++ b/server/src/routes/routes.ts
@@ -32,6 +32,12 @@ export const routes = (app: Application) => {
     jenkinsController.getBuildStatusHandler
   ); // http://localhost:3000/jenkins/job/MyJob/build/1
 
+  // Get deployment status
+  app.get(
+    "/jenkins/deployment-status/:jobName",
+    jenkinsController.getDeploymentStatus
+  ); // http://localhost:3000/jenkins/deployment-status/MyJob
+
   // Create a Jenkins job and trigger it
   app.post(
     "/jenkins/job",


### PR DESCRIPTION
### Changes
- Changed `projectType` enum value from `.NetCore` to `DotNetCore` and from `Node.js` to `Nodejs`

- Implemented a 10-second timeout for log streaming to handle cases where no data is received.
- Added [`clearTimeout`]
- Added console logs for:
  - Stream initialization (`"Log stream initialized"`)
  - Data chunks received (`"Received data chunk: "`)
  - Stream end (`"Log stream ended."`)
  - Stream errors (`"Error in log stream:"`)
