### PR TITLE
fix: handle deletion of both Jenkins jobs and associated Kubernetes resources

### DIFF
--- a/server/src/helpers/pipeline.ts
+++ b/server/src/helpers/pipeline.ts
@@ -56,7 +56,7 @@ spec:
       - name: ${sanitizedProjectType}-container
         image: ${imageName}
         ports:
-        - containerPort: 8080
+        - containerPort: 80
         env: ${envYaml}
   `;
 

--- a/server/src/helpers/pipeline.ts
+++ b/server/src/helpers/pipeline.ts
@@ -259,7 +259,7 @@ pipeline {
   agent any
   environment {
     IMAGE_NAME = "${escapedImageName}"
-    MINIKUBE_URL = 'http://127.0.0.1:34931'
+    MINIKUBE_URL = 'http://127.0.0.1:37147'
     KUBECONFIG = '/home/jenkins/.kube/config'
   }
   stages {

--- a/server/src/service/jenkinsService.ts
+++ b/server/src/service/jenkinsService.ts
@@ -81,3 +81,10 @@ export const getJobWithBuilds = async (jobName: string) => {
 export const updateJob = async (jobName: string, jobConfigXml: string) => {
   await jenkins.job.config(jobName, jobConfigXml);
 };
+
+export const isK8sJob = async (jobName: string): Promise<boolean> => {
+  // Logic to determine if the job corresponds to a Kubernetes job
+  //  check the job configuration or metadata for a Kubernetes association
+  const jobConfig = await jenkins.job.config(jobName);
+  return jobConfig.includes("<kubernetes-plugin-namespace>");
+};


### PR DESCRIPTION

**Changes**

- Added logic to check if a Jenkins job is Kubernetes-related using `jenkinsService.isK8sJob`.
- Added logic to delete the corresponding Kubernetes namespace using `deleteNamespace`.
- Ensured that the Jenkins job is deleted regardless of Kubernetes association.
- Added error handling to log failures in Kubernetes namespace deletion but still proceed with Jenkins job deletion.